### PR TITLE
Fix plugin to return correct month

### DIFF
--- a/jqClock.js
+++ b/jqClock.js
@@ -158,7 +158,7 @@ if(!Date.prototype.hasOwnProperty("isDST")){
 					    s=mytimestamp_sysdiff.getSeconds(),
 					    dy=mytimestamp_sysdiff.getDay(),
 					    dt=mytimestamp_sysdiff.getDate(),
-					    mo=mytimestamp_sysdiff.getMonth(),
+					    mo=mytimestamp_sysdiff.getMonth()+1,
 					    y=mytimestamp_sysdiff.getFullYear(),
 					    ap="AM",
 					    calend="";


### PR DESCRIPTION
README says that format character 'm' returns 01 through 12,
but I specified "m" to dateFormat and got "05" though it's June.
Date.getMonth returns 0 through 11, so it seems we have to plus one to it.